### PR TITLE
renamed oc-config to cs-config

### DIFF
--- a/opencog/CMakeLists.txt
+++ b/opencog/CMakeLists.txt
@@ -2,7 +2,7 @@
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
-DECLARE_GUILE_CONFIG_TARGET(SCM_CONFIG "opencog oc-config" "OPENCOG_TEST")
+DECLARE_GUILE_CONFIG_TARGET(SCM_CONFIG "opencog cs-config" "OPENCOG_TEST")
 
 # The build order used here is loosely in terms of
 # dependencies: the later parts depend on, or may
@@ -13,7 +13,7 @@ IF (HAVE_SERVER)
 	ADD_SUBDIRECTORY (cogserver)
 ENDIF(HAVE_SERVER)
 
-WRITE_GUILE_CONFIG(${GUILE_BIN_DIR}/opencog/oc-config.scm SCM_CONFIG TRUE)
+WRITE_GUILE_CONFIG(${GUILE_BIN_DIR}/opencog/cs-config.scm SCM_CONFIG TRUE)
 
-WRITE_GUILE_CONFIG(${GUILE_BIN_DIR}/opencog/oc-config-installable.scm SCM_CONFIG FALSE)
-INSTALL(FILES ${GUILE_BIN_DIR}/opencog/oc-config-installable.scm DESTINATION ${GUILE_SITE_DIR}/opencog RENAME oc-config.scm)
+WRITE_GUILE_CONFIG(${GUILE_BIN_DIR}/opencog/cs-config-installable.scm SCM_CONFIG FALSE)
+INSTALL(FILES ${GUILE_BIN_DIR}/opencog/cs-config-installable.scm DESTINATION ${GUILE_SITE_DIR}/opencog RENAME cs-config.scm)

--- a/opencog/cogserver/scm/cogserver.scm
+++ b/opencog/cogserver/scm/cogserver.scm
@@ -5,9 +5,9 @@
 (define-module (opencog cogserver))
 
 (use-modules (opencog))
-(use-modules (opencog oc-config))
+(use-modules (opencog cs-config))
 
-; Path to libguile-cogserver.so is set up in the oc-config module.
+; Path to libguile-cogserver.so is set up in the cs-config module.
 (load-extension
 	(string-append opencog-ext-path-cogserver "libguile-cogserver")
 	"opencog_cogserver_init")


### PR DESCRIPTION
Fix to https://github.com/opencog/opencog/issues/3615
As suggested by @leungmanhin , changed name of config file to avoid overwriting by opencog build