### PR TITLE
Remove create_singleton_instance argument

### DIFF
--- a/opencog/cogserver/shell/PythonShellModule.cc
+++ b/opencog/cogserver/shell/PythonShellModule.cc
@@ -50,8 +50,7 @@ PythonShellModule::PythonShellModule(CogServer& cs) : Module(cs)
 	global_python_initialize();
 
 	// Tell the python evaluator to create its singleton instance
-	// with our atomspace.
-	PythonEval::create_singleton_instance(&cs.getAtomSpace());
+	PythonEval::create_singleton_instance();
 }
 
 PythonShellModule::~PythonShellModule()


### PR DESCRIPTION
In [this commit](https://github.com/opencog/atomspace/commit/a60c8135236f590832aa7c86fc188393c7a18477
) parameter for `create_singleton_instance` was removed and I've seen it already applied in other repos.

Note that `ShellUTest` started failing for me, so I opened [this issue](https://github.com/opencog/opencog-nix/issues/46). Not sure if it passes on non nix systems.