### PR TITLE
Make the number of open sockets configurable

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -41,13 +41,19 @@ CogServer::CogServer(AtomSpace* as) :
 {
 }
 
-void CogServer::enableNetworkServer(int port)
+/// Open the given port number for network service.
+/// Allow at most `max_open_socks` concurrent connections.
+/// Setting this larger than 10 or 20 will usually lead to
+/// poor performance, and setting it larger than 140 will
+/// require changing the unix ulimit on max open file descriptors.
+void CogServer::enableNetworkServer(int port, int max_open_socks)
 {
     if (_networkServer) return;
     _networkServer = new NetworkServer(config().get_int("SERVER_PORT", port));
 
+    ConsoleSocket::set_max_open_sockets(max_open_socks);
     auto make_console = [](void)->ConsoleSocket*
-	     { return new ServerConsole(); };
+            { return new ServerConsole(); };
     _networkServer->run(make_console);
     _running = true;
 }

--- a/opencog/cogserver/server/CogServer.h
+++ b/opencog/cogserver/server/CogServer.h
@@ -81,7 +81,8 @@ public:
     /** Starts the network server and adds the default command line
      *  server socket on the port specified by the configuration
      *  parameter SERVER_PORT */
-    virtual void enableNetworkServer(int port=17001);
+    virtual void enableNetworkServer(int port=17001,
+                                     int max_open_socks=10);
 
     /** Stops the network server and closes all the open server sockets. */
     virtual void disableNetworkServer(void);

--- a/opencog/network/ConsoleSocket.h
+++ b/opencog/network/ConsoleSocket.h
@@ -102,8 +102,9 @@ public:
      * Assorted debugging utilities.
      */
     unsigned int get_use_count() const { return _use_count; }
-    unsigned int get_max_open_sockets() const { return _max_open_sockets; }
-    unsigned int get_num_open_sockets() const { return _num_open_sockets; }
+    static void set_max_open_sockets(unsigned int m) { _max_open_sockets = m; }
+    static unsigned int get_max_open_sockets() { return _max_open_sockets; }
+    static unsigned int get_num_open_sockets() { return _num_open_sockets; }
 }; // class
 
 /** @}*/


### PR DESCRIPTION
Some unit tests want a larger-than default value.