### PR TITLE
Set thread names for cogserver threads.

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/prctl.h>
 
 #include <opencog/util/Logger.h>
 #include <opencog/util/misc.h>
@@ -70,6 +71,7 @@ void CogServer::stop()
 
 void CogServer::serverLoop()
 {
+    prctl(PR_SET_NAME, "cogserv:loop", 0, 0, 0);
     logger().info("Starting CogServer loop.");
     while (_running)
     {

--- a/opencog/network/GenericShell.cc
+++ b/opencog/network/GenericShell.cc
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <sys/prctl.h>
+
 #include <chrono>
 #include <mutex>
 #include <thread>
@@ -422,6 +424,7 @@ void GenericShell::while_not_done()
 /// it is impossible to queue OOB interrupts.)
 void GenericShell::eval_loop(void)
 {
+	prctl(PR_SET_NAME, "cogserv:eval", 0, 0, 0);
 	logger().debug("[GenericShell] enter eval loop");
 	OC_ASSERT(nullptr == _evaluator, "Bad evaluator state!");
 
@@ -541,6 +544,7 @@ void GenericShell::wake_poll(void)
 void GenericShell::poll_loop(void)
 {
 	_init_done = true;
+	prctl(PR_SET_NAME, "cogserv:poll", 0, 0, 0);
 
 	std::unique_lock<std::mutex> lock(_poll_mtx);
 

--- a/opencog/network/NetworkServer.cc
+++ b/opencog/network/NetworkServer.cc
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>
+#include <sys/prctl.h>
 
 #include <boost/asio/ip/tcp.hpp>
 #include <opencog/util/Logger.h>
@@ -58,6 +59,7 @@ void NetworkServer::stop()
 
 void NetworkServer::listen(void)
 {
+    prctl(PR_SET_NAME, "cogserv:listen", 0, 0, 0);
     printf("Listening on port %d\n", _port);
     while (_running)
     {

--- a/opencog/network/ServerSocket.cc
+++ b/opencog/network/ServerSocket.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <sys/prctl.h>
 #include <mutex>
 
 #include <opencog/util/Logger.h>
@@ -161,6 +162,7 @@ void ServerSocket::set_connection(boost::asio::ip::tcp::socket* sock)
 
 void ServerSocket::handle_connection(void)
 {
+    prctl(PR_SET_NAME, "cogserv:connect", 0, 0, 0);
     logger().debug("ServerSocket::handle_connection()");
     OnConnection();
     boost::asio::streambuf b;


### PR DESCRIPTION
This should simplify debugging.