### PR TITLE
Remove most usage of the singleton instance

### DIFF
--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -89,7 +89,7 @@ void CogServer::enableWebServer(int port)
     _webServer = new NetworkServer(port, "WebSocket Server");
 
     auto make_console = [](void)->ServerSocket* {
-        ServerSocket* ss = new WebServer();
+        ServerSocket* ss = new WebServer(cogserver());
         ss->act_as_http_socket();
         return ss;
     };

--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -110,7 +110,7 @@ void CogServer::enableMCPServer(int port)
     _mcpServer = new NetworkServer(port, "Model Context Protocol Server");
 
     auto make_console = [](void)->ServerSocket* {
-        ServerSocket* ss = new MCPServer();
+        ServerSocket* ss = new MCPServer(cogserver());
         ss->act_as_mcp();
         return ss;
     };

--- a/opencog/cogserver/server/CogServer.cc
+++ b/opencog/cogserver/server/CogServer.cc
@@ -75,7 +75,7 @@ void CogServer::enableNetworkServer(int port)
     _consoleServer = new NetworkServer(port, "Telnet Server");
 
     auto make_console = [](void)->ServerSocket*
-            { return new ServerConsole(); };
+            { return new ServerConsole(cogserver()); };
     _consoleServer->run(make_console);
     _running = true;
     logger().info("Network server running on port %d", port);

--- a/opencog/cogserver/server/MCPServer.cc
+++ b/opencog/cogserver/server/MCPServer.cc
@@ -20,7 +20,8 @@
 
 using namespace opencog;
 
-MCPServer::MCPServer(void)
+MCPServer::MCPServer(CogServer& cs) :
+	_cserver(cs)
 {
 	_eval = nullptr;
 }
@@ -45,7 +46,7 @@ void MCPServer::OnConnection(void)
 
 	// If there's no shell, then set up an evaluator for ourself.
 	if (nullptr == _shell)
-		_eval = McpEval::get_evaluator(cogserver().getAtomSpace());
+		_eval = McpEval::get_evaluator(_cserver.getAtomSpace());
 }
 
 // Called for each newline-terminated line received.

--- a/opencog/cogserver/server/MCPServer.h
+++ b/opencog/cogserver/server/MCPServer.h
@@ -11,7 +11,6 @@
 #include <string>
 
 #include <opencog/network/ConsoleSocket.h>
-#include <opencog/cogserver/server/Request.h>
 #include <opencog/cogserver/shell/McpEval.h>
 
 namespace opencog

--- a/opencog/cogserver/server/MCPServer.h
+++ b/opencog/cogserver/server/MCPServer.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <opencog/network/ConsoleSocket.h>
+#include <opencog/cogserver/server/CogServer.h>
 #include <opencog/cogserver/shell/McpEval.h>
 
 namespace opencog
@@ -25,6 +26,7 @@ namespace opencog
 class MCPServer : public ConsoleSocket
 {
 private:
+	CogServer& _cserver;
 	McpEval* _eval;
 
 protected:
@@ -32,7 +34,7 @@ protected:
 	virtual void OnLine (const std::string&);
 
 public:
-    MCPServer(void);
+    MCPServer(CogServer&);
     ~MCPServer();
 
 }; // class

--- a/opencog/cogserver/server/RequestManager.cc
+++ b/opencog/cogserver/server/RequestManager.cc
@@ -69,7 +69,7 @@ Request* RequestManager::createRequest(const std::string& name,
         logger().debug("Cannot create unknown request \"%s\"", name.c_str());
         return nullptr;
     }
-    return it->second->create(cogserver());
+    return it->second->create(cs);
 }
 
 const RequestClassInfo& RequestManager::requestInfo(const std::string& name) const

--- a/opencog/cogserver/server/ServerConsole.cc
+++ b/opencog/cogserver/server/ServerConsole.cc
@@ -22,7 +22,8 @@ using namespace opencog;
 
 std::string ServerConsole::_prompt;
 
-ServerConsole::ServerConsole(void)
+ServerConsole::ServerConsole(CogServer& cs) :
+	_cserver(cs)
 {
     if (nullptr == &config()) {
         _prompt = "[0;32mopencog[1;32m> [0m";
@@ -317,7 +318,7 @@ void ServerConsole::OnLine(const std::string& line)
 
     // If the cogserver has stopped, then the command processor is gone,
     // and we just ... can't handle commands any longer. Self-destruct.
-    CogServer& cs = cogserver();
+    CogServer& cs = _cserver;
     if (not cs.running())
     {
         Exit();

--- a/opencog/cogserver/server/ServerConsole.h
+++ b/opencog/cogserver/server/ServerConsole.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include <opencog/network/ConsoleSocket.h>
+#include <opencog/cogserver/server/CogServer.h>
 
 namespace opencog
 {
@@ -36,6 +37,7 @@ private:
     static std::string _prompt;
 
 protected:
+    CogServer& _cserver;
     bool handle_telnet_iac(const std::string&);
 
     /**
@@ -65,7 +67,7 @@ public:
      * Ctor. Defines the socket's mime-type as 'text/plain' and then
      * configures the Socket to use line protocol.
      */
-    ServerConsole(void);
+    ServerConsole(CogServer&);
     ~ServerConsole();
 
     /**

--- a/opencog/cogserver/server/WebServer.cc
+++ b/opencog/cogserver/server/WebServer.cc
@@ -19,7 +19,8 @@
 
 using namespace opencog;
 
-WebServer::WebServer(void) :
+WebServer::WebServer(CogServer& cs) :
+	_cserver(cs),
 	_request(nullptr)
 {
 }
@@ -52,8 +53,7 @@ void WebServer::OnConnection(void)
 	// whatever, and, stripping away the leading slash, it
 	// should be one of the supported comands.
 	std::string cmdName = _url.substr(1);
-	CogServer& cs = cogserver();
-	_request = cs.createRequest(cmdName);
+	_request = _cserver.createRequest(cmdName);
 
 	// Reject URL's we don't know about.
 	if (nullptr == _request)
@@ -113,12 +113,12 @@ std::string WebServer::html_stats(void)
 		"<body>"
 		"<h2>Loaded Modules</h2>"
 		"<pre>\n";
-	response += cogserver().listModules();
+	response += _cserver.listModules();
 	response +=
 		"</pre>"
 		"<h2>CogServer Stats</h2>"
 		"<pre>\n";
-	response += cogserver().display_web_stats();
+	response += _cserver.display_web_stats();
 	response +=
 		"</pre>"
 		"<h2>CogServer Stats Legend</h2>"

--- a/opencog/cogserver/server/WebServer.h
+++ b/opencog/cogserver/server/WebServer.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <opencog/network/ConsoleSocket.h>
+#include <opencog/cogserver/server/CogServer.h>
 #include <opencog/cogserver/server/Request.h>
 
 namespace opencog
@@ -28,6 +29,7 @@ namespace opencog
 class WebServer : public ConsoleSocket
 {
 private:
+	CogServer& _cserver;
 	Request* _request;
 
 protected:
@@ -37,7 +39,7 @@ protected:
 	std::string html_stats(void);
 	std::string favicon(void);
 public:
-    WebServer(void);
+    WebServer(CogServer&);
     ~WebServer();
 
 }; // class

--- a/opencog/cogserver/shell/JsonShell.cc
+++ b/opencog/cogserver/shell/JsonShell.cc
@@ -21,14 +21,13 @@
  */
 
 #include <opencog/persist/json/JsonEval.h>
-#include <opencog/atomspace/AtomSpace.h>
-#include <opencog/cogserver/server/CogServer.h>
 
 #include "JsonShell.h"
 
 using namespace opencog;
 
-JsonShell::JsonShell(void)
+JsonShell::JsonShell(const AtomSpacePtr& asp) :
+	_shellspace(asp)
 {
 	normal_prompt = "json> ";
 	abort_prompt = "json> ";
@@ -44,7 +43,7 @@ JsonShell::~JsonShell()
 
 GenericEval* JsonShell::get_evaluator(void)
 {
-	return JsonEval::get_evaluator(cogserver().getAtomSpace());
+	return JsonEval::get_evaluator(_shellspace);
 }
 
 /* ===================== END OF FILE ============================ */

--- a/opencog/cogserver/shell/JsonShell.h
+++ b/opencog/cogserver/shell/JsonShell.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_JSON_SHELL_H
 
 #include <opencog/network/GenericShell.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog {
 /** \addtogroup grp_server
@@ -32,8 +33,10 @@ namespace opencog {
 
 class JsonShell : public GenericShell
 {
+	protected:
+		AtomSpacePtr _shellspace;
 	public:
-		JsonShell(void);
+		JsonShell(const AtomSpacePtr&);
 		virtual ~JsonShell();
 		virtual GenericEval* get_evaluator(void);
 };

--- a/opencog/cogserver/shell/JsonShellModule.cc
+++ b/opencog/cogserver/shell/JsonShellModule.cc
@@ -84,7 +84,7 @@ JsonShellModule::shelloutRequest::execute(void)
 	ConsoleSocket *con = this->get_console();
 	OC_ASSERT(con, "Invalid Request object");
 
-	JsonShell *sh = new JsonShell();
+	JsonShell *sh = new JsonShell(_cogserver.getAtomSpace());
 	sh->set_socket(con);
 
 	if (!_parameters.empty())

--- a/opencog/cogserver/shell/McpShell.cc
+++ b/opencog/cogserver/shell/McpShell.cc
@@ -20,15 +20,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atomspace/AtomSpace.h>
-#include <opencog/cogserver/server/CogServer.h>
-
 #include "McpEval.h"
 #include "McpShell.h"
 
 using namespace opencog;
 
-McpShell::McpShell(void)
+McpShell::McpShell(const AtomSpacePtr& asp) :
+	_shellspace(asp)
 {
 	normal_prompt = "mcp> ";
 	abort_prompt = "mcp> ";
@@ -44,7 +42,7 @@ McpShell::~McpShell()
 
 GenericEval* McpShell::get_evaluator(void)
 {
-	return McpEval::get_evaluator(cogserver().getAtomSpace());
+	return McpEval::get_evaluator(_shellspace);
 }
 
 /* ===================== END OF FILE ============================ */

--- a/opencog/cogserver/shell/McpShell.h
+++ b/opencog/cogserver/shell/McpShell.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_MCP_SHELL_H
 
 #include <opencog/network/GenericShell.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog {
 /** \addtogroup grp_server
@@ -32,8 +33,10 @@ namespace opencog {
 
 class McpShell : public GenericShell
 {
+	protected:
+		AtomSpacePtr _shellspace;
 	public:
-		McpShell(void);
+		McpShell(const AtomSpacePtr&);
 		virtual ~McpShell();
 		virtual GenericEval* get_evaluator(void);
 };

--- a/opencog/cogserver/shell/McpShellModule.cc
+++ b/opencog/cogserver/shell/McpShellModule.cc
@@ -84,7 +84,7 @@ McpShellModule::shelloutRequest::execute(void)
 	ConsoleSocket *con = this->get_console();
 	OC_ASSERT(con, "Invalid Request object");
 
-	McpShell *sh = new McpShell();
+	McpShell *sh = new McpShell(_cogserver.getAtomSpace());
 	sh->set_socket(con);
 
 	if (!_parameters.empty())

--- a/opencog/cogserver/shell/SchemeShell.cc
+++ b/opencog/cogserver/shell/SchemeShell.cc
@@ -33,7 +33,8 @@ using namespace opencog;
 
 std::string SchemeShell::_prompt;
 
-SchemeShell::SchemeShell(void)
+SchemeShell::SchemeShell(const AtomSpacePtr& asp) :
+	_shellspace(asp)
 {
 	_prompt = "[0;34mguile[1;34m> [0m";
 
@@ -53,7 +54,7 @@ SchemeShell::SchemeShell(void)
 	_name = " scm";
 
 	// Set the inital atomspace for this thread.
-	SchemeEval::set_scheme_as(cogserver().getAtomSpace().get());
+	SchemeEval::set_scheme_as(_shellspace.get());
 }
 
 SchemeShell::~SchemeShell()
@@ -67,7 +68,7 @@ SchemeShell::~SchemeShell()
 
 GenericEval* SchemeShell::get_evaluator(void)
 {
-	return SchemeEval::get_evaluator(cogserver().getAtomSpace());
+	return SchemeEval::get_evaluator(_shellspace);
 }
 
 /**
@@ -75,7 +76,7 @@ GenericEval* SchemeShell::get_evaluator(void)
  */
 void SchemeShell::thread_init(void)
 {
-	SchemeEval::set_scheme_as(cogserver().getAtomSpace().get());
+	SchemeEval::set_scheme_as(_shellspace.get());
 }
 
 #endif

--- a/opencog/cogserver/shell/SchemeShell.h
+++ b/opencog/cogserver/shell/SchemeShell.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include <opencog/network/GenericShell.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog {
 /** \addtogroup grp_server
@@ -37,11 +38,12 @@ namespace opencog {
 class SchemeShell : public GenericShell
 {
 	protected:
+		AtomSpacePtr _shellspace;
 		void thread_init();
 		static std::string _prompt;
 
 	public:
-		SchemeShell(void);
+		SchemeShell(const AtomSpacePtr&);
 		virtual ~SchemeShell();
 		virtual GenericEval* get_evaluator(void);
 };

--- a/opencog/cogserver/shell/SchemeShellModule.cc
+++ b/opencog/cogserver/shell/SchemeShellModule.cc
@@ -90,7 +90,7 @@ SchemeShellModule::shelloutRequest::execute(void)
 	ConsoleSocket *con = this->get_console();
 	OC_ASSERT(con, "Invalid Request object");
 
-	SchemeShell *sh = new SchemeShell();
+	SchemeShell *sh = new SchemeShell(_cogserver.getAtomSpace());
 	sh->set_socket(con);
 
 	if (!_parameters.empty())

--- a/opencog/cogserver/shell/SexprShell.cc
+++ b/opencog/cogserver/shell/SexprShell.cc
@@ -21,14 +21,13 @@
  */
 
 #include <opencog/persist/sexcom/SexprEval.h>
-#include <opencog/atomspace/AtomSpace.h>
-#include <opencog/cogserver/server/CogServer.h>
 
 #include "SexprShell.h"
 
 using namespace opencog;
 
-SexprShell::SexprShell(void)
+SexprShell::SexprShell(const AtomSpacePtr& asp) :
+	_shellspace(asp)
 {
 	normal_prompt = "";
 	abort_prompt = "";
@@ -44,7 +43,7 @@ SexprShell::~SexprShell()
 
 GenericEval* SexprShell::get_evaluator(void)
 {
-	return SexprEval::get_evaluator(cogserver().getAtomSpace());
+	return SexprEval::get_evaluator(_shellspace);
 }
 
 /* ===================== END OF FILE ============================ */

--- a/opencog/cogserver/shell/SexprShell.h
+++ b/opencog/cogserver/shell/SexprShell.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_SEXPR_SHELL_H
 
 #include <opencog/network/GenericShell.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog {
 /** \addtogroup grp_server
@@ -32,8 +33,10 @@ namespace opencog {
 
 class SexprShell : public GenericShell
 {
+	protected:
+		AtomSpacePtr _shellspace;
 	public:
-		SexprShell(void);
+		SexprShell(const AtomSpacePtr&);
 		virtual ~SexprShell();
 		virtual GenericEval* get_evaluator(void);
 };

--- a/opencog/cogserver/shell/SexprShellModule.cc
+++ b/opencog/cogserver/shell/SexprShellModule.cc
@@ -89,7 +89,7 @@ SexprShellModule::shelloutRequest::execute(void)
 	ConsoleSocket *con = this->get_console();
 	OC_ASSERT(con, "Invalid Request object");
 
-	SexprShell *sh = new SexprShell();
+	SexprShell *sh = new SexprShell(_cogserver.getAtomSpace());
 
 	sh->set_socket(con);
 	send("");

--- a/opencog/cogserver/shell/TopEval.cc
+++ b/opencog/cogserver/shell/TopEval.cc
@@ -29,8 +29,9 @@
 using namespace opencog;
 using namespace std::chrono_literals;
 
-TopEval::TopEval()
-	: GenericEval()
+TopEval::TopEval(CogServer& cs)
+	: GenericEval(),
+	_cserver(cs)
 {
 	_started = false;
 	_done = false;
@@ -120,7 +121,7 @@ std::string TopEval::poll_result()
 
 	// Send the telnet clear-screen command.
 	ret += "\u001B[2J";
-	ret += cogserver().display_stats(_nlines);
+	ret += _cserver.display_stats(_nlines);
 
 	if (0 < _msg.size())
 	{
@@ -167,9 +168,9 @@ void TopEval::interrupt(void)
 
 // One evaluator per thread.  This allows multiple users to each
 // have thier own evaluator.
-TopEval* TopEval::get_evaluator()
+TopEval* TopEval::get_evaluator(CogServer& cs)
 {
-	static thread_local TopEval* evaluator = new TopEval();
+	static thread_local TopEval* evaluator = new TopEval(cs);
 
 	// The eval_dtor runs when this thread is destroyed.
 	class eval_dtor {

--- a/opencog/cogserver/shell/TopEval.h
+++ b/opencog/cogserver/shell/TopEval.h
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <string>
 #include <opencog/eval/GenericEval.h>
+#include <opencog/cogserver/server/CogServer.h>
 
 /**
  * The TopEval class implements a very simple API for reporting server
@@ -41,6 +42,7 @@ namespace opencog {
 class TopEval : public GenericEval
 {
 	private:
+		CogServer& _cserver;
 		std::mutex _sleep_mtx;
 		std::condition_variable _sleeper;
 		double _refresh;
@@ -49,7 +51,7 @@ class TopEval : public GenericEval
 		bool _done;
 		std::string _msg;
 
-		TopEval();
+		TopEval(CogServer&);
 
 	public:
 		virtual ~TopEval();
@@ -63,7 +65,7 @@ class TopEval : public GenericEval
 		void cmd();
 		void set_interval(double);
 
-		static TopEval* get_evaluator();
+		static TopEval* get_evaluator(CogServer&);
 };
 
 /** @}*/

--- a/opencog/cogserver/shell/TopShell.cc
+++ b/opencog/cogserver/shell/TopShell.cc
@@ -25,7 +25,8 @@
 
 using namespace opencog;
 
-TopShell::TopShell(void)
+TopShell::TopShell(CogServer& cs) :
+	_shellserver(cs)
 {
 	normal_prompt = "top> ";
 	abort_prompt = "";
@@ -62,7 +63,7 @@ void TopShell::line_discipline(const std::string& expr)
 
 GenericEval* TopShell::get_evaluator(void)
 {
-	_top_eval = TopEval::get_evaluator();
+	_top_eval = TopEval::get_evaluator(_shellserver);
 	_top_eval->set_interval(_refresh);
 	return _top_eval;
 }

--- a/opencog/cogserver/shell/TopShell.h
+++ b/opencog/cogserver/shell/TopShell.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include <opencog/network/GenericShell.h>
+#include <opencog/cogserver/server/CogServer.h>
 
 namespace opencog {
 /** \addtogroup grp_server
@@ -36,6 +37,7 @@ class TopEval;
 class TopShell : public GenericShell
 {
 	private:
+		CogServer& _shellserver;
 		TopEval* _top_eval;
 		double _refresh;
 
@@ -44,7 +46,7 @@ class TopShell : public GenericShell
 		virtual void line_discipline(const std::string&);
 
 	public:
-		TopShell(void);
+		TopShell(CogServer&);
 		virtual ~TopShell();
 		virtual GenericEval* get_evaluator(void);
 

--- a/opencog/cogserver/shell/TopShellModule.cc
+++ b/opencog/cogserver/shell/TopShellModule.cc
@@ -78,7 +78,7 @@ TopShellModule::shelloutRequest::execute(void)
 	ConsoleSocket *con = this->get_console();
 	OC_ASSERT(con, "Invalid Request object");
 
-	TopShell *sh = new TopShell();
+	TopShell *sh = new TopShell(_cogserver);
 	sh->set_socket(con);
 
 	if (!_parameters.empty())


### PR DESCRIPTION
This removes many but not all uses of the cogserver singleton instance.

The goal here is to lay groundwork for a future revision that is more microservices-oriented. But for now, due to how tcp/ip sockets work on unix, we can't really have more than one server per unix process anyway, so most of the change here is kind-of pointless-ish.  Still, it narrows down the usage of a global. 